### PR TITLE
2 Line trains have the wrong direction set

### DIFF
--- a/data/trains.html
+++ b/data/trains.html
@@ -157,12 +157,6 @@
       .state-moving {
         color: #9cdcfe;
       }
-      .dir-northbound {
-        color: #dcdcaa;
-      }
-      .dir-southbound {
-        color: #c586c0;
-      }
       .line-1 {
         color: #4ec9b0;
       }

--- a/src/TrainDataManager.cpp
+++ b/src/TrainDataManager.cpp
@@ -143,7 +143,7 @@ bool TrainDataManager::parseTrainDataFromJson(JsonDocument& doc, Line line) {
     auto tripIt = tripMap.find(train.tripId);
     if (tripIt != tripMap.end()) {
       TripInfo& tripInfo = tripIt->second;
-      train.direction =  tripInfo.directionId;
+      train.direction = tripInfo.directionId;
       train.routeId = tripInfo.routeId;
       train.tripHeadsign = tripInfo.tripHeadsign;
     }


### PR DESCRIPTION
Fixes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LED display mapping for 2-line stations to properly align top and bottom indicators with directional information.

* **Updates**
  * Removed the Direction column from train listings for a cleaner table layout.
  * Train destinations now display with a "To: " prefix for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->